### PR TITLE
Added Most recent attack status container

### DIFF
--- a/src/main/java/assets/css/custom.css
+++ b/src/main/java/assets/css/custom.css
@@ -199,16 +199,14 @@ margin: 38px 0;
 
  .player1-changelog{
  border: 1px solid black;
- width: 48%;
- height: 50px;
- float: left;
-
+ width: 400px;
+ height: 75px;
+ display: inline-block;
  }
 
  .player2-changelog{
  border: 1px solid black;
- width: 48%;
- height: 50px;
- float: right;
-
+ width: 400px;
+ height: 75px;
+ display: inline-block;
  }

--- a/src/main/java/assets/game.js
+++ b/src/main/java/assets/game.js
@@ -36,6 +36,38 @@ function makeGrid(table, isPlayer) {
 
 }
 
+function printAction(player, attack){
+    var row = attack.location['row'];
+    var column = attack.location['column'];
+    var status = attack.result;
+
+    var log, text;
+
+    /*Player is equal to the board that is being attacked. SO if opponent, the player is attacking the opponent ship*/
+    if(player == "opponent"){
+        log_container = document.getElementById("player-log");
+        log = document.getElementById("player-status");
+        log.innerHTML = "";
+
+        text = document.createElement("p");
+        text.appendChild(document.createTextNode('You attacked ' + column + ' ' + row + ' and it resulted in a ' + status + '.'));
+        log.appendChild(text);
+
+        log_container.scrollTop = log.scrollHeight;
+    }
+
+    else if(player == "player"){
+        log_container = document.getElementById("opponent-log");
+        log = document.getElementById("opponent-status");
+        log.innerHTML = "";
+
+        text = document.createElement("p");
+        text.appendChild(document.createTextNode('Your opponent has attacked ' + column + ' ' + row + ' and it resulted in a ' + status + '.'));
+        log.appendChild(text);
+
+        log_container.scrollTop = log.scrollHeight;
+    }
+}
 
 
 function markHits(board, elementId, surrenderText) {
@@ -45,23 +77,16 @@ function markHits(board, elementId, surrenderText) {
         let className;
 
         if (attack.result === "MISS")
-
             className = "miss";
-
         else if (attack.result === "HIT")
-
             className = "hit";
-
         else if (attack.result === "SUNK")
-
             className = "hit"
-
         else if (attack.result === "SURRENDER")
-
             showModal(surrenderText);
-
         document.getElementById(elementId).rows[attack.location.row-1].cells[attack.location.column.charCodeAt(0) - 'A'.charCodeAt(0)].classList.add(className);
 
+        printAction(elementId, attack);
     });
 
 }
@@ -133,7 +158,7 @@ function registerCellListener(f) {
 function cellClick() {
     let row = this.parentNode.rowIndex + 1;
     let col = String.fromCharCode(this.cellIndex + 65);
-    console.log(col);
+
     if (isSetup) {
         if (shipType == undefined || placedShips.includes(shipType))
         {
@@ -157,22 +182,14 @@ function cellClick() {
         sendXhr("POST", "/place", {game: game, shipType: shipType, x: row, y: col, isVertical: vertical}, function(data) {
             game = data;
             redrawGrid();
-
             placedShips.push(shipType);
-
             if (placedShips.length == 3) {
-
                 isSetup = false;
-
                 registerCellListener((e) => {});
-
                 document.getElementById('player').classList.remove("clickable");
                 document.getElementById('opponent').classList.add("clickable");
-
             }
-
             shipType = undefined;
-
         });
 
     } else {
@@ -181,21 +198,14 @@ function cellClick() {
             showModal("guess-board");
             return;
         }
-
         else if (this.classList.contains("miss") || this.classList.contains("hit")){
             showModal("guess-double");
             return;
         }
-
-
         sendXhr("POST", "/attack", {game: game, x: row, y: col}, function(data) {
-
             game = data;
-
             redrawGrid();
-
         })
-
     }
 
 }

--- a/src/main/java/views/ApplicationController/index.ftl.html
+++ b/src/main/java/views/ApplicationController/index.ftl.html
@@ -1,40 +1,44 @@
-<#import "../layout/defaultLayout.ftl.html" as layout> 
-<@layout.myLayout "Home page">    
+<#import "../layout/defaultLayout.ftl.html" as layout>
+<@layout.myLayout "Home page">
 
 
 <h1 align="center">Battleships for Fun</h1>
 
 <div class="changelog-wrapper">
-    <div class="player1-changelog"> change log...</div>
+    <div id="player-log" class="player1-changelog">
+        <div id = "player-status"></div>
+    </div>
 
-    <div class="player2-changelog"> change log...</div>
+    <div id = "opponent-log" class="player2-changelog">
+        <div id ="opponent-status"></div>
+    </div>
 </div>
 
 <div class="row">
 
-<div class="scoreboard-player1">
-    <div class="ships-scoreboard">
+    <div class="scoreboard-player1">
+        <div class="ships-scoreboard">
 
-        <div class="row" id="placement">
-            <ul><h2>Ships</h2>
-                <li><button id="place_minesweeper">Place Minesweeper</button></li>
-                <li><button id="place_destroyer">Place Destroyer</button></li>
-                <li><button id="place_battleship">Place Battleship</button></li>
-            </ul>
+            <div class="row" id="placement">
+                <ul><h2>Ships</h2>
+                    <li><button id="place_minesweeper">Place Minesweeper</button></li>
+                    <li><button id="place_destroyer">Place Destroyer</button></li>
+                    <li><button id="place_battleship">Place Battleship</button></li>
+                </ul>
+            </div>
+
         </div>
 
-    </div>
+        <input type="checkbox" id="is_vertical">Vertical</input>
 
-    <input type="checkbox" id="is_vertical">Vertical</input>
-
-    <div class="hits-and-miss-player1">
-        <ul>
-            <li>Hits:  </li>
-            <li>Miss: </li>
-        </ul>
+        <div class="hits-and-miss-player1">
+            <ul>
+                <li>Hits:  </li>
+                <li>Miss: </li>
+            </ul>
+        </div>
+        <h2 align="left">Player1</h2>
     </div>
-    <h2 align="left">Player1</h2>
-</div>
 
 
 
@@ -83,60 +87,60 @@
     </div>
 
     <div class="numbers">
-            <table class="table">
-                <tr>
-                </tr>
-                <tr>
-                    <th>
-                        1
-                    </th>
-                </tr>
-                <tr>
-                    <th>
-                        2
-                    </th>
-                </tr>
-                <tr>
-                    <th>
-                        3
-                    </th>
-                </tr>
-                <tr>
-                    <th>
-                        4
-                    </th>
-                </tr>
-                <tr>
-                    <th>
-                        5
-                    </th>
-                </tr>
-                <tr>
-                    <th>
-                        6
-                    </th>
-                </tr>
-                <tr>
-                    <th>
-                        7
-                    </th>
-                </tr>
-                <tr>
-                    <th>
-                        8
-                    </th>
-                </tr>
-                <tr>
-                    <th>
-                        9
-                    </th>
-                </tr>
-                <tr>
-                    <th>
-                        10
-                    </th>
-                </tr>
-            </table>
+        <table class="table">
+            <tr>
+            </tr>
+            <tr>
+                <th>
+                    1
+                </th>
+            </tr>
+            <tr>
+                <th>
+                    2
+                </th>
+            </tr>
+            <tr>
+                <th>
+                    3
+                </th>
+            </tr>
+            <tr>
+                <th>
+                    4
+                </th>
+            </tr>
+            <tr>
+                <th>
+                    5
+                </th>
+            </tr>
+            <tr>
+                <th>
+                    6
+                </th>
+            </tr>
+            <tr>
+                <th>
+                    7
+                </th>
+            </tr>
+            <tr>
+                <th>
+                    8
+                </th>
+            </tr>
+            <tr>
+                <th>
+                    9
+                </th>
+            </tr>
+            <tr>
+                <th>
+                    10
+                </th>
+            </tr>
+        </table>
     </div>
 
     <div class="bf bfPlayer2">


### PR DESCRIPTION
I kept the two status containers in the center because we need to adjust the positioning of the board. We can come back to the status to update based off the final positioning. 

Another thing to note: This only updates the most recent action. I had a problem where it printed repeated actions, which is most likely caused by the board redrawing all hits and misses again.